### PR TITLE
Hardcoded  version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,13 +5,12 @@
   <modelVersion>4.0.0</modelVersion>
   
   <properties>
-    <revision>1.0</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   
   <groupId>org.jc</groupId>
   <artifactId>parent</artifactId>
-  <version>${revision}</version>
+  <version>1.0</version>
   <packaging>pom</packaging>
   
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jc</groupId>
     <artifactId>parent</artifactId>
-    <version>${revision}</version>
+    <version>1.0</version>
     <relativePath>parent</relativePath>
   </parent>
   

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jc</groupId>
     <artifactId>parent</artifactId>
-    <version>${revision}</version>
+    <version>1.0</version>
     <relativePath>../parent</relativePath>
   </parent>
   

--- a/tool/src/main/java/org/jc/api/IdentifiedSource.java
+++ b/tool/src/main/java/org/jc/api/IdentifiedSource.java
@@ -23,9 +23,9 @@ public class IdentifiedSource extends IdentifiedFile {
 
     public String getSourceCode() throws UnsupportedEncodingException {
         if (encoding.isPresent()) {
-            return new String(getFile());
-        } else {
             return new String(getFile(), encoding.get());
+        } else {
+            return new String(getFile());
         }
     }
 }


### PR DESCRIPTION
Without it, the project can not be used as depndence.
Macrosin poms do nto work like this
This project is very wierdly organised
The parent must be installed separately